### PR TITLE
Feat: 웹뷰와 웹 위치 정보 받기 로직 분리

### DIFF
--- a/src/app/map/_hooks/useGeoLocation.tsx
+++ b/src/app/map/_hooks/useGeoLocation.tsx
@@ -25,6 +25,13 @@ const useGeoLocation = () => {
   const polylineRef = useRef<naver.maps.Polyline | null>(null);
 
   useEffect(() => {
+    if (typeof window !== "undefined" && window.ReactNativeWebView) {
+      alert("웹뷰입니다!!");
+      // 웹뷰에서 위치정보 동의 받고 현재 위치받아오기
+      return;
+    }
+    alert("웹페이지입니다!!");
+
     const { geolocation } = navigator;
     if (!geolocation) return;
 

--- a/src/app/map/_hooks/useGeoLocation.tsx
+++ b/src/app/map/_hooks/useGeoLocation.tsx
@@ -28,6 +28,9 @@ const useGeoLocation = () => {
     if (typeof window !== "undefined" && window.ReactNativeWebView) {
       alert("웹뷰입니다!!");
       // 웹뷰에서 위치정보 동의 받고 현재 위치받아오기
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: "REQUEST_GPS_PERMISSIONS" }),
+      );
       return;
     }
     alert("웹페이지입니다!!");

--- a/src/app/map/_hooks/useGeoLocation.tsx
+++ b/src/app/map/_hooks/useGeoLocation.tsx
@@ -35,6 +35,8 @@ const useGeoLocation = () => {
         JSON.stringify({ type: "REQUEST_GPS_PERMISSIONS" }),
       );
       window.addEventListener("message", handleMessage);
+      // android 추후에 확인
+      // document.addEventListener("message", handleMessage);
     } else {
       const { geolocation } = navigator;
       if (geolocation) {
@@ -57,6 +59,8 @@ const useGeoLocation = () => {
     return () => {
       if (typeof window !== "undefined" && window.ReactNativeWebView) {
         window.removeEventListener("message", handleMessage);
+        // android 추후에 확인
+        // document.removeEventListener("message", handleMessage);
       }
     };
   }, []);


### PR DESCRIPTION
## 🔧 작업 내용

App과 Web의 위치정보를 받는 로직을 분리하여 작성하였습니다.

## 🔎 작업 중 특이사항 및 정리사항

- Web -> App : window.ReactNativeWebView.postMessage
- App -> Web : window.addEventListener("message", handleMessage);

- iOs: window.addEventListener, Android : document.addEventListener (추후 확인 예정)

## 📄 레퍼런스
[참고 블로그](https://2yh-develop4jeon.tistory.com/m/96)